### PR TITLE
feat: Codex CLI session parser (#8 phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-compatible-8A2BE2?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0id2hpdGUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGNpcmNsZSBjeD0iOCIgY3k9IjgiIHI9IjYiIGZpbGw9Im5vbmUiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMS41Ii8+PGNpcmNsZSBjeD0iOCIgY3k9IjgiIHI9IjIiLz48L3N2Zz4=)](https://modelcontextprotocol.io/)
 
-> Semantic search over your Claude Code session history. Ask questions about past conversations by meaning, not just keywords.
+> Semantic search over your AI coding agent session history. Ask questions about past conversations by meaning, not just keywords.
 
-**deja** is an [MCP server](https://modelcontextprotocol.io/) that indexes Claude Code JSONL sessions and provides hybrid search (vector + full-text) directly from Claude Code.
+**deja** is an [MCP server](https://modelcontextprotocol.io/) that indexes JSONL sessions from supported AI coding agents and provides hybrid search (vector + full-text) directly from Claude Code.
+
+## Supported sources
+
+| Source | Path | Status |
+|--------|------|--------|
+| Claude Code | `~/.claude/projects/*/*.jsonl` | Supported |
+| Codex CLI | `~/.codex/sessions/YYYY/MM/DD/*.jsonl` | Supported (v0.4+) |
+| Cursor / Gemini / OpenCode | — | Planned ([#8](https://github.com/CynepMyx/deja/issues/8)) |
 
 ## How it works
 
@@ -49,11 +57,13 @@ First run downloads the embedding model (~117 MB).
 ### Build the index
 
 ```bash
-deja index              # incremental — only new/changed files
-deja index --reindex    # full rebuild
+deja index                       # incremental, all sources
+deja index --reindex             # full rebuild
+deja index --source claude-code  # only Claude Code sessions
+deja index --source codex        # only Codex CLI sessions
 ```
 
-Scans all `~/.claude/projects/*/*.jsonl` files.
+Scans every supported source by default. Filter with `--source`.
 
 ### Add to Claude Code
 
@@ -84,6 +94,7 @@ Restart Claude Code — deja will appear as a connected MCP server.
 - `query` (string) — what to search for
 - `limit` (int, default 10) — max results
 - `project` (string, optional) — filter by project
+- `source` (string, optional) — filter by source: `claude-code`, `codex`
 - `date_from` / `date_to` (string, optional) — ISO date range
 
 ### Auto-indexing (optional)

--- a/src/deja/chunker.py
+++ b/src/deja/chunker.py
@@ -28,7 +28,7 @@ def _split_text(text: str) -> list[str]:
     return chunks
 
 def make_chunks(
-    turn: dict, session_id: str, project_path: str
+    turn: dict, session_id: str, project_path: str, source: str = "claude-code"
 ) -> list[dict]:
     embed_text = f"{turn['user_text']}\n\n{turn['assistant_text']}"
     parts = _split_text(embed_text)
@@ -42,6 +42,7 @@ def make_chunks(
             "split_index": i,
             "timestamp": turn.get("timestamp", ""),
             "project_path": project_path,
+            "source": source,
         }
         for i, part in enumerate(parts)
     ]

--- a/src/deja/cli.py
+++ b/src/deja/cli.py
@@ -9,7 +9,8 @@ if sys.stdout.encoding and sys.stdout.encoding.lower().replace("-", "") != "utf8
 
 from deja.db import init_db, get_meta, SCHEMA_VERSION
 from deja.indexer import get_embedding_model, index_file, gc_orphans
-from deja.config import get_index_dir, get_index_path, CLAUDE_PROJECTS_DIR
+from deja.config import get_index_dir, get_index_path
+from deja.parsers.registry import all_sources, get_parser
 
 def _acquire_lock():
     index_dir = get_index_dir()
@@ -36,20 +37,15 @@ def _release_lock(lock_fd):
     except OSError:
         pass
 
-def _find_jsonl_files() -> list[tuple[str, str]]:
+def _collect_files(sources: list[str]) -> list[tuple[str, str, str]]:
+    """Return [(path, project_path, source), ...] across the requested sources."""
     results = []
-    if not os.path.isdir(CLAUDE_PROJECTS_DIR):
-        print(f"[deja] {CLAUDE_PROJECTS_DIR} not found", file=sys.stderr)
-        return results
-
-    for project_dir in os.listdir(CLAUDE_PROJECTS_DIR):
-        full_project = os.path.join(CLAUDE_PROJECTS_DIR, project_dir)
-        if not os.path.isdir(full_project):
-            continue
-        for jsonl in glob.glob(os.path.join(full_project, "*.jsonl")):
-            results.append((jsonl, project_dir))
-
+    for src in sources:
+        parser = get_parser(src)
+        for path, project_path in parser.discover():
+            results.append((path, project_path, src))
     return results
+
 
 def cmd_index(args):
     lock_fd = _acquire_lock()
@@ -68,17 +64,23 @@ def cmd_index(args):
             conn.execute("DELETE FROM indexed_files")
             conn.commit()
 
+        sources = all_sources() if args.source == "all" else [args.source]
+        print(f"[deja] sources: {', '.join(sources)}", file=sys.stderr)
+
         print("[deja] loading embedding model...", file=sys.stderr)
         model = get_embedding_model()
 
-        files = _find_jsonl_files()
+        files = _collect_files(sources)
         print(f"[deja] found {len(files)} JSONL files", file=sys.stderr)
 
         known_paths = set()
-        for i, (path, project) in enumerate(files):
+        for i, (path, project, src) in enumerate(files):
             known_paths.add(path)
-            print(f"[deja] [{i+1}/{len(files)}] {os.path.basename(path)}", file=sys.stderr)
-            index_file(conn, model, path, project)
+            print(
+                f"[deja] [{i+1}/{len(files)}] [{src}] {os.path.basename(path)}",
+                file=sys.stderr,
+            )
+            index_file(conn, model, path, project, source=src)
 
         gc_orphans(conn, known_paths)
         conn.close()
@@ -228,6 +230,12 @@ def main():
 
     idx = sub.add_parser("index", help="Index JSONL session files")
     idx.add_argument("--reindex", action="store_true", help="Force full reindex")
+    idx.add_argument(
+        "--source",
+        default="all",
+        choices=["all", *all_sources()],
+        help="Which source(s) to index (default: all)",
+    )
 
     sub.add_parser("serve", help="Start MCP server (stdio)")
 

--- a/src/deja/cli.py
+++ b/src/deja/cli.py
@@ -82,7 +82,7 @@ def cmd_index(args):
             )
             index_file(conn, model, path, project, source=src)
 
-        gc_orphans(conn, known_paths)
+        gc_orphans(conn, known_paths, sources=sources)
         conn.close()
         print("[deja] indexing complete", file=sys.stderr)
     finally:

--- a/src/deja/cli.py
+++ b/src/deja/cli.py
@@ -173,17 +173,21 @@ def cmd_search(args):
     print("Loading model...", file=sys.stderr)
     model = get_embedding_model()
 
-    results = hybrid_search(conn, model, args.query, limit=args.limit, project=args.project)
+    results = hybrid_search(
+        conn, model, args.query, limit=args.limit,
+        project=args.project, source=args.source,
+    )
 
     if not results:
         print("No results found.")
     else:
         for i, r in enumerate(results, 1):
             score = r.get("score", 0)
+            src = r.get("source", "?")
             sid = r.get("session_id", "?")[:12]
             ts = r.get("timestamp", "")[:19]
             text = r.get("chunk_text", "")[:200].replace("\n", " ")
-            print(f"\n[{i}] score={score:.4f} | {sid} | {ts}")
+            print(f"\n[{i}] score={score:.4f} | [{src}] {sid} | {ts}")
             print(f"    {text}")
 
     conn.close()
@@ -245,6 +249,12 @@ def main():
     sr.add_argument("query", help="Search query")
     sr.add_argument("--limit", type=int, default=5, help="Max results (default: 5)")
     sr.add_argument("--project", default=None, help="Filter by project path")
+    sr.add_argument(
+        "--source",
+        default=None,
+        choices=all_sources(),
+        help="Filter by source (claude-code, codex, ...)",
+    )
 
     sub.add_parser("redact", help="Redact secrets in existing index (no re-embedding)")
 

--- a/src/deja/config.py
+++ b/src/deja/config.py
@@ -5,6 +5,7 @@ APP_NAME = "deja"
 LEGACY_INDEX_DIR = os.path.join(os.path.expanduser("~"), ".claude", "deja")
 DEFAULT_INDEX_DIR = user_data_dir(APP_NAME, appauthor=False, ensure_exists=False)
 CLAUDE_PROJECTS_DIR = os.path.join(os.path.expanduser("~"), ".claude", "projects")
+CODEX_SESSIONS_DIR = os.path.join(os.path.expanduser("~"), ".codex", "sessions")
 
 
 def get_index_dir() -> str:

--- a/src/deja/db.py
+++ b/src/deja/db.py
@@ -2,7 +2,7 @@ import sqlite3
 import struct
 import sqlite_vec
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 EMBEDDING_MODEL = "intfloat/multilingual-e5-small"
 EMBEDDING_DIM = 384
 
@@ -29,6 +29,7 @@ def init_db(db_path: str) -> sqlite3.Connection:
             project_path TEXT,
             chunk_text TEXT NOT NULL,
             tool_result_text TEXT,
+            source TEXT NOT NULL DEFAULT 'claude-code',
             UNIQUE(session_id, message_index, split_index)
         );
 
@@ -62,6 +63,7 @@ def init_db(db_path: str) -> sqlite3.Connection:
     conn.executescript("""
         CREATE INDEX IF NOT EXISTS idx_chunks_session ON chunks(session_id);
         CREATE INDEX IF NOT EXISTS idx_chunks_project_time ON chunks(project_path, timestamp);
+        CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks(source);
     """)
 
     meta_defaults = {

--- a/src/deja/db.py
+++ b/src/deja/db.py
@@ -4,7 +4,7 @@ import sys
 
 import sqlite_vec
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 EMBEDDING_MODEL = "intfloat/multilingual-e5-small"
 EMBEDDING_DIM = 384
 

--- a/src/deja/db.py
+++ b/src/deja/db.py
@@ -74,7 +74,8 @@ def init_db(db_path: str) -> sqlite3.Connection:
             last_offset INTEGER NOT NULL DEFAULT 0,
             last_mtime REAL NOT NULL,
             last_size INTEGER NOT NULL,
-            source TEXT NOT NULL DEFAULT 'claude-code'
+            source TEXT NOT NULL DEFAULT 'claude-code',
+            next_message_index INTEGER
         );
 
         CREATE TABLE IF NOT EXISTS meta (

--- a/src/deja/db.py
+++ b/src/deja/db.py
@@ -1,5 +1,7 @@
 import sqlite3
 import struct
+import sys
+
 import sqlite_vec
 
 SCHEMA_VERSION = 2
@@ -8,6 +10,38 @@ EMBEDDING_DIM = 384
 
 def serialize_f32(vector: list[float]) -> bytes:
     return struct.pack("%sf" % len(vector), *vector)
+
+def _migrate_if_needed(conn: sqlite3.Connection):
+    """Drop index tables when the on-disk schema version differs.
+
+    Tables are recreated by init_db right after; data is rebuilt by the
+    next `deja index`. Must run before any DDL that references new columns.
+    """
+    has_meta = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'meta'"
+    ).fetchone()
+    if not has_meta:
+        return
+
+    db_version = int(get_meta(conn).get("schema_version", "0"))
+    if db_version == SCHEMA_VERSION:
+        return
+
+    print(
+        f"[deja] schema v{db_version} -> v{SCHEMA_VERSION}: "
+        "rebuilding index tables, run 'deja index' to repopulate",
+        file=sys.stderr,
+    )
+    conn.executescript("""
+        DROP TABLE IF EXISTS chunks;
+        DROP TABLE IF EXISTS indexed_files;
+        DROP TABLE IF EXISTS chunks_vec;
+        DROP TABLE IF EXISTS chunks_fts;
+    """)
+    conn.execute(
+        "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', ?)",
+        (str(SCHEMA_VERSION),),
+    )
 
 def init_db(db_path: str) -> sqlite3.Connection:
     conn = sqlite3.connect(db_path)
@@ -18,6 +52,8 @@ def init_db(db_path: str) -> sqlite3.Connection:
     conn.execute("PRAGMA journal_mode = WAL")
     conn.execute("PRAGMA synchronous = NORMAL")
     conn.execute("PRAGMA busy_timeout = 5000")
+
+    _migrate_if_needed(conn)
 
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS chunks (
@@ -37,7 +73,8 @@ def init_db(db_path: str) -> sqlite3.Connection:
             path TEXT PRIMARY KEY,
             last_offset INTEGER NOT NULL DEFAULT 0,
             last_mtime REAL NOT NULL,
-            last_size INTEGER NOT NULL
+            last_size INTEGER NOT NULL,
+            source TEXT NOT NULL DEFAULT 'claude-code'
         );
 
         CREATE TABLE IF NOT EXISTS meta (

--- a/src/deja/indexer.py
+++ b/src/deja/indexer.py
@@ -129,12 +129,12 @@ def index_file(
         # Commit after each batch — crash-safe resume from last committed offset
         batch_offset = batch_turns[-1].get("completed_offset", None)
         if batch_offset:
-            _update_file_meta(conn, path, batch_offset)
+            _update_file_meta(conn, path, batch_offset, source=source)
         conn.commit()
         indexed_any = True
 
     if not indexed_any:
-        _update_file_meta(conn, path, offset)
+        _update_file_meta(conn, path, offset, source=source)
         conn.commit()
 
 def _upsert_chunk(conn, chunk: dict, embedding):
@@ -183,17 +183,29 @@ def _upsert_chunk(conn, chunk: dict, embedding):
             (chunk_id, chunk["chunk_text"], chunk.get("tool_result_text", "")),
         )
 
-def _update_file_meta(conn, path: str, completed_offset: int = None):
+def _update_file_meta(conn, path: str, completed_offset: int = None, source: str = "claude-code"):
     stat = os.stat(path)
     offset = completed_offset if completed_offset else stat.st_size
     conn.execute(
-        """INSERT OR REPLACE INTO indexed_files (path, last_offset, last_mtime, last_size)
-        VALUES (?, ?, ?, ?)""",
-        (path, offset, stat.st_mtime, stat.st_size),
+        """INSERT OR REPLACE INTO indexed_files (path, last_offset, last_mtime, last_size, source)
+        VALUES (?, ?, ?, ?, ?)""",
+        (path, offset, stat.st_mtime, stat.st_size, source),
     )
 
-def gc_orphans(conn, known_paths: set[str]):
-    indexed = conn.execute("SELECT path FROM indexed_files").fetchall()
+def gc_orphans(conn, known_paths: set[str], sources: list[str] = None):
+    """Remove index entries for files that no longer exist on disk.
+
+    `sources` limits gc to files indexed from those sources — a partial run
+    (`deja index --source codex`) must not treat other sources' files as orphans.
+    """
+    if sources is None:
+        indexed = conn.execute("SELECT path FROM indexed_files").fetchall()
+    else:
+        placeholders = ",".join("?" * len(sources))
+        indexed = conn.execute(
+            f"SELECT path FROM indexed_files WHERE source IN ({placeholders})",
+            sources,
+        ).fetchall()
     for (path,) in indexed:
         if path not in known_paths:
             session_id = os.path.splitext(os.path.basename(path))[0]

--- a/src/deja/indexer.py
+++ b/src/deja/indexer.py
@@ -6,7 +6,6 @@ from fastembed.text.text_embedding import PoolingType, ModelSource
 from deja.db import serialize_f32
 from deja.parsers.registry import get_parser
 from deja.chunker import make_chunks
-from deja.secrets import redact
 
 EMBED_BATCH_SIZE = 32
 TURNS_PER_BATCH = 50
@@ -136,9 +135,6 @@ def index_file(
             all_embeddings.extend(model.embed(emb_batch))
 
         for chunk, embedding in zip(chunks, all_embeddings):
-            chunk["chunk_text"] = redact(chunk["chunk_text"])
-            if chunk.get("tool_result_text"):
-                chunk["tool_result_text"] = redact(chunk["tool_result_text"])
             try:
                 _upsert_chunk(conn, chunk, embedding)
             except Exception as e:

--- a/src/deja/indexer.py
+++ b/src/deja/indexer.py
@@ -55,18 +55,34 @@ def _delete_file_chunks(conn, session_id: str):
         conn.execute("DELETE FROM chunks_fts WHERE rowid = ?", (cid,))
     conn.execute("DELETE FROM chunks WHERE session_id = ?", (session_id,))
 
+def _delete_chunks_from(conn, session_id: str, from_index: int):
+    ids = conn.execute(
+        "SELECT id FROM chunks WHERE session_id = ? AND message_index >= ?",
+        (session_id, from_index),
+    ).fetchall()
+    for (cid,) in ids:
+        conn.execute("DELETE FROM chunks_vec WHERE rowid = ?", (cid,))
+        conn.execute("DELETE FROM chunks_fts WHERE rowid = ?", (cid,))
+    conn.execute(
+        "DELETE FROM chunks WHERE session_id = ? AND message_index >= ?",
+        (session_id, from_index),
+    )
+
 def _get_resume_state(conn, session_id: str, path: str) -> tuple[int, int]:
     row = conn.execute(
-        "SELECT last_offset FROM indexed_files WHERE path = ?", (path,)
+        "SELECT last_offset, next_message_index FROM indexed_files WHERE path = ?",
+        (path,),
     ).fetchone()
-    offset = row[0] if row else 0
-
-    row = conn.execute(
-        "SELECT MAX(message_index) FROM chunks WHERE session_id = ?",
-        (session_id,),
+    if row is None:
+        return 0, 0
+    offset = row[0]
+    if row[1] is not None:
+        return offset, row[1]
+    # legacy rows without next_message_index: derive from chunks
+    row2 = conn.execute(
+        "SELECT MAX(message_index) FROM chunks WHERE session_id = ?", (session_id,)
     ).fetchone()
-    start_idx = (row[0] + 1) if row and row[0] is not None else 0
-
+    start_idx = (row2[0] + 1) if row2 and row2[0] is not None else 0
     return offset, start_idx
 
 def _iter_batches(iterator, size):
@@ -97,6 +113,7 @@ def index_file(
         _delete_file_chunks(conn, session_id)
     elif needs == "incremental":
         offset, start_message_index = _get_resume_state(conn, session_id, path)
+        _delete_chunks_from(conn, session_id, start_message_index)
 
     parser = get_parser(source)
     turns_gen = parser.parse(path, offset=offset, start_message_index=start_message_index)
@@ -127,14 +144,16 @@ def index_file(
                 print(f"[deja] error inserting chunk: {e}", file=sys.stderr)
 
         # Commit after each batch — crash-safe resume from last committed offset
-        batch_offset = batch_turns[-1].get("completed_offset", None)
-        if batch_offset:
-            _update_file_meta(conn, path, batch_offset, source=source)
+        last = batch_turns[-1]
+        batch_offset = last.get("completed_offset", None)
+        next_idx = last["message_index"] if last.get("provisional") else last["message_index"] + 1
+        if batch_offset is not None:
+            _update_file_meta(conn, path, batch_offset, source=source, next_message_index=next_idx)
         conn.commit()
         indexed_any = True
 
     if not indexed_any:
-        _update_file_meta(conn, path, offset, source=source)
+        _update_file_meta(conn, path, offset, source=source, next_message_index=start_message_index)
         conn.commit()
 
 def _upsert_chunk(conn, chunk: dict, embedding):
@@ -183,13 +202,15 @@ def _upsert_chunk(conn, chunk: dict, embedding):
             (chunk_id, chunk["chunk_text"], chunk.get("tool_result_text", "")),
         )
 
-def _update_file_meta(conn, path: str, completed_offset: int = None, source: str = "claude-code"):
+def _update_file_meta(conn, path: str, completed_offset: int = None,
+                      source: str = "claude-code", next_message_index: int = None):
     stat = os.stat(path)
     offset = completed_offset if completed_offset is not None else stat.st_size
     conn.execute(
-        """INSERT OR REPLACE INTO indexed_files (path, last_offset, last_mtime, last_size, source)
-        VALUES (?, ?, ?, ?, ?)""",
-        (path, offset, stat.st_mtime, stat.st_size, source),
+        """INSERT OR REPLACE INTO indexed_files
+           (path, last_offset, last_mtime, last_size, source, next_message_index)
+        VALUES (?, ?, ?, ?, ?, ?)""",
+        (path, offset, stat.st_mtime, stat.st_size, source, next_message_index),
     )
 
 def gc_orphans(conn, known_paths: set[str], sources: list[str] = None):

--- a/src/deja/indexer.py
+++ b/src/deja/indexer.py
@@ -138,14 +138,16 @@ def _upsert_chunk(conn, chunk: dict, embedding):
         (chunk["session_id"], chunk["message_index"], chunk["split_index"]),
     ).fetchone()
 
+    source = chunk.get("source", "claude-code")
     if row:
         chunk_id = row[0]
         conn.execute(
             """UPDATE chunks SET timestamp = ?, project_path = ?,
-               chunk_text = ?, tool_result_text = ?
+               chunk_text = ?, tool_result_text = ?, source = ?
                WHERE id = ?""",
             (chunk["timestamp"], chunk["project_path"],
-             chunk["chunk_text"], chunk.get("tool_result_text", ""), chunk_id),
+             chunk["chunk_text"], chunk.get("tool_result_text", ""),
+             source, chunk_id),
         )
         conn.execute(
             "INSERT OR REPLACE INTO chunks_vec (rowid, embedding) VALUES (?, ?)",
@@ -158,11 +160,11 @@ def _upsert_chunk(conn, chunk: dict, embedding):
     else:
         cursor = conn.execute(
             """INSERT INTO chunks
-            (session_id, message_index, split_index, timestamp, project_path, chunk_text, tool_result_text)
-            VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (session_id, message_index, split_index, timestamp, project_path, chunk_text, tool_result_text, source)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (chunk["session_id"], chunk["message_index"], chunk["split_index"],
              chunk["timestamp"], chunk["project_path"], chunk["chunk_text"],
-             chunk.get("tool_result_text", "")),
+             chunk.get("tool_result_text", ""), source),
         )
         chunk_id = cursor.lastrowid
         conn.execute(

--- a/src/deja/indexer.py
+++ b/src/deja/indexer.py
@@ -185,7 +185,7 @@ def _upsert_chunk(conn, chunk: dict, embedding):
 
 def _update_file_meta(conn, path: str, completed_offset: int = None, source: str = "claude-code"):
     stat = os.stat(path)
-    offset = completed_offset if completed_offset else stat.st_size
+    offset = completed_offset if completed_offset is not None else stat.st_size
     conn.execute(
         """INSERT OR REPLACE INTO indexed_files (path, last_offset, last_mtime, last_size, source)
         VALUES (?, ?, ?, ?, ?)""",

--- a/src/deja/indexer.py
+++ b/src/deja/indexer.py
@@ -4,7 +4,7 @@ from itertools import islice
 from fastembed import TextEmbedding
 from fastembed.text.text_embedding import PoolingType, ModelSource
 from deja.db import serialize_f32
-from deja.parser import parse_jsonl_file
+from deja.parsers.registry import get_parser
 from deja.chunker import make_chunks
 from deja.secrets import redact
 
@@ -77,7 +77,13 @@ def _iter_batches(iterator, size):
             break
         yield batch
 
-def index_file(conn, model: TextEmbedding, path: str, project_path: str):
+def index_file(
+    conn,
+    model: TextEmbedding,
+    path: str,
+    project_path: str,
+    source: str = "claude-code",
+):
     session_id = os.path.splitext(os.path.basename(path))[0]
     needs = check_needs_reindex(conn, path)
 
@@ -92,13 +98,14 @@ def index_file(conn, model: TextEmbedding, path: str, project_path: str):
     elif needs == "incremental":
         offset, start_message_index = _get_resume_state(conn, session_id, path)
 
-    turns_gen = parse_jsonl_file(path, offset=offset, start_message_index=start_message_index)
+    parser = get_parser(source)
+    turns_gen = parser.parse(path, offset=offset, start_message_index=start_message_index)
     indexed_any = False
 
     for batch_turns in _iter_batches(turns_gen, TURNS_PER_BATCH):
         chunks = []
         for turn in batch_turns:
-            chunks.extend(make_chunks(turn, session_id, project_path))
+            chunks.extend(make_chunks(turn, session_id, project_path, source=source))
 
         if not chunks:
             continue

--- a/src/deja/indexer.py
+++ b/src/deja/indexer.py
@@ -115,6 +115,7 @@ def index_file(
         offset, start_message_index = _get_resume_state(conn, session_id, path)
         _delete_chunks_from(conn, session_id, start_message_index)
 
+    stat_before = os.stat(path)
     parser = get_parser(source)
     turns_gen = parser.parse(path, offset=offset, start_message_index=start_message_index)
     indexed_any = False
@@ -148,12 +149,12 @@ def index_file(
         batch_offset = last.get("completed_offset", None)
         next_idx = last["message_index"] if last.get("provisional") else last["message_index"] + 1
         if batch_offset is not None:
-            _update_file_meta(conn, path, batch_offset, source=source, next_message_index=next_idx)
+            _update_file_meta(conn, path, batch_offset, source=source, next_message_index=next_idx, stat_result=stat_before)
         conn.commit()
         indexed_any = True
 
     if not indexed_any:
-        _update_file_meta(conn, path, offset, source=source, next_message_index=start_message_index)
+        _update_file_meta(conn, path, offset, source=source, next_message_index=start_message_index, stat_result=stat_before)
         conn.commit()
 
 def _upsert_chunk(conn, chunk: dict, embedding):
@@ -203,8 +204,9 @@ def _upsert_chunk(conn, chunk: dict, embedding):
         )
 
 def _update_file_meta(conn, path: str, completed_offset: int = None,
-                      source: str = "claude-code", next_message_index: int = None):
-    stat = os.stat(path)
+                      source: str = "claude-code", next_message_index: int = None,
+                      stat_result=None):
+    stat = stat_result if stat_result is not None else os.stat(path)
     offset = completed_offset if completed_offset is not None else stat.st_size
     conn.execute(
         """INSERT OR REPLACE INTO indexed_files

--- a/src/deja/parser.py
+++ b/src/deja/parser.py
@@ -1,104 +1,13 @@
-import json
-import sys
-from typing import Generator
+from deja.parsers.claude_code import (
+    TOOL_RESULT_MAX,
+    extract_content,
+    parse_jsonl_file,
+    get_file_end_offset,
+)
 
-TOOL_RESULT_MAX = 2000
-
-def extract_content(content) -> tuple[str, str]:
-    if isinstance(content, str):
-        return content, ""
-
-    text_parts = []
-    tool_result_parts = []
-
-    for block in content:
-        block_type = block.get("type", "")
-
-        if block_type == "text":
-            text_parts.append(block.get("text", ""))
-
-        elif block_type == "tool_use":
-            name = block.get("name", "unknown")
-            inp = block.get("input", {})
-            if isinstance(inp, dict):
-                cmd = inp.get("command", inp.get("file_path", inp.get("query", "")))
-            else:
-                cmd = str(inp)[:200]
-            text_parts.append(f"[Tool: {name}] {cmd}")
-
-        elif block_type == "tool_result":
-            raw = block.get("content", "")
-            if isinstance(raw, list):
-                raw = " ".join(
-                    b.get("text", "") for b in raw if isinstance(b, dict)
-                )
-            if isinstance(raw, str):
-                tool_result_parts.append(raw[:TOOL_RESULT_MAX])
-
-        elif block_type == "thinking":
-            continue
-
-    return "\n".join(text_parts), "\n".join(tool_result_parts)
-
-def parse_jsonl_file(
-    path: str, offset: int = 0, start_message_index: int = 0
-) -> Generator[dict, None, None]:
-    pending_user = None
-    message_index = start_message_index
-
-    with open(path, "r", encoding="utf-8") as f:
-        if offset > 0:
-            f.seek(offset)
-
-        while True:
-            line = f.readline()
-            if not line:
-                break
-            line = line.strip()
-            if not line:
-                continue
-
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                print(f"[deja] skipping malformed line in {path}", file=sys.stderr)
-                continue
-
-            entry_type = entry.get("type", "")
-
-            if entry_type == "summary":
-                continue
-
-            message = entry.get("message", {})
-            content = message.get("content", [])
-            timestamp = entry.get("timestamp", "")
-
-            if entry_type == "user":
-                text, tool_text = extract_content(content)
-                pending_user = {
-                    "text": text,
-                    "tool_result": tool_text,
-                    "timestamp": timestamp,
-                }
-
-            elif entry_type == "assistant" and pending_user is not None:
-                text, tool_text = extract_content(content)
-                combined_tool = "\n".join(
-                    filter(None, [pending_user["tool_result"], tool_text])
-                )
-                completed_offset = f.tell()
-                yield {
-                    "user_text": pending_user["text"],
-                    "assistant_text": text,
-                    "tool_result_text": combined_tool[:TOOL_RESULT_MAX],
-                    "timestamp": timestamp or pending_user["timestamp"],
-                    "message_index": message_index,
-                    "completed_offset": completed_offset,
-                }
-                message_index += 1
-                pending_user = None
-
-def get_file_end_offset(path: str) -> int:
-    with open(path, "rb") as f:
-        f.seek(0, 2)
-        return f.tell()
+__all__ = [
+    "TOOL_RESULT_MAX",
+    "extract_content",
+    "parse_jsonl_file",
+    "get_file_end_offset",
+]

--- a/src/deja/parsers/base.py
+++ b/src/deja/parsers/base.py
@@ -1,0 +1,25 @@
+from typing import Iterator, Protocol
+
+
+class Parser(Protocol):
+    """Source-specific session parser.
+
+    Each parser:
+    1. Knows where its source stores session files on disk (`discover`).
+    2. Knows how to read one file and emit normalized turns (`parse`).
+
+    Turns must be dicts with keys:
+        user_text, assistant_text, tool_result_text,
+        timestamp, message_index, completed_offset
+    """
+
+    SOURCE: str
+
+    def discover(self) -> Iterator[tuple[str, str]]:
+        """Yield (file_path, project_path) for every session file on disk."""
+        ...
+
+    def parse(
+        self, path: str, offset: int = 0, start_message_index: int = 0
+    ) -> Iterator[dict]:
+        ...

--- a/src/deja/parsers/claude_code.py
+++ b/src/deja/parsers/claude_code.py
@@ -1,0 +1,104 @@
+import json
+import sys
+from typing import Generator
+
+TOOL_RESULT_MAX = 2000
+
+def extract_content(content) -> tuple[str, str]:
+    if isinstance(content, str):
+        return content, ""
+
+    text_parts = []
+    tool_result_parts = []
+
+    for block in content:
+        block_type = block.get("type", "")
+
+        if block_type == "text":
+            text_parts.append(block.get("text", ""))
+
+        elif block_type == "tool_use":
+            name = block.get("name", "unknown")
+            inp = block.get("input", {})
+            if isinstance(inp, dict):
+                cmd = inp.get("command", inp.get("file_path", inp.get("query", "")))
+            else:
+                cmd = str(inp)[:200]
+            text_parts.append(f"[Tool: {name}] {cmd}")
+
+        elif block_type == "tool_result":
+            raw = block.get("content", "")
+            if isinstance(raw, list):
+                raw = " ".join(
+                    b.get("text", "") for b in raw if isinstance(b, dict)
+                )
+            if isinstance(raw, str):
+                tool_result_parts.append(raw[:TOOL_RESULT_MAX])
+
+        elif block_type == "thinking":
+            continue
+
+    return "\n".join(text_parts), "\n".join(tool_result_parts)
+
+def parse_jsonl_file(
+    path: str, offset: int = 0, start_message_index: int = 0
+) -> Generator[dict, None, None]:
+    pending_user = None
+    message_index = start_message_index
+
+    with open(path, "r", encoding="utf-8") as f:
+        if offset > 0:
+            f.seek(offset)
+
+        while True:
+            line = f.readline()
+            if not line:
+                break
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                print(f"[deja] skipping malformed line in {path}", file=sys.stderr)
+                continue
+
+            entry_type = entry.get("type", "")
+
+            if entry_type == "summary":
+                continue
+
+            message = entry.get("message", {})
+            content = message.get("content", [])
+            timestamp = entry.get("timestamp", "")
+
+            if entry_type == "user":
+                text, tool_text = extract_content(content)
+                pending_user = {
+                    "text": text,
+                    "tool_result": tool_text,
+                    "timestamp": timestamp,
+                }
+
+            elif entry_type == "assistant" and pending_user is not None:
+                text, tool_text = extract_content(content)
+                combined_tool = "\n".join(
+                    filter(None, [pending_user["tool_result"], tool_text])
+                )
+                completed_offset = f.tell()
+                yield {
+                    "user_text": pending_user["text"],
+                    "assistant_text": text,
+                    "tool_result_text": combined_tool[:TOOL_RESULT_MAX],
+                    "timestamp": timestamp or pending_user["timestamp"],
+                    "message_index": message_index,
+                    "completed_offset": completed_offset,
+                }
+                message_index += 1
+                pending_user = None
+
+def get_file_end_offset(path: str) -> int:
+    with open(path, "rb") as f:
+        f.seek(0, 2)
+        return f.tell()

--- a/src/deja/parsers/claude_code.py
+++ b/src/deja/parsers/claude_code.py
@@ -63,13 +63,34 @@ def parse_jsonl_file(
     path: str, offset: int = 0, start_message_index: int = 0
 ) -> Generator[dict, None, None]:
     pending_user = None
+    asst_parts: list[str] = []
+    asst_tools: list[str] = []
+    last_ts = ""
+    turn_start = offset
     message_index = start_message_index
+
+    def _build(completed_offset: int, provisional: bool = False) -> dict:
+        combined_tool = "\n".join(
+            filter(None, [pending_user["tool_result"], *asst_tools])
+        )
+        turn = {
+            "user_text": pending_user["text"],
+            "assistant_text": "\n\n".join(asst_parts),
+            "tool_result_text": combined_tool[:TOOL_RESULT_MAX],
+            "timestamp": last_ts or pending_user["timestamp"],
+            "message_index": message_index,
+            "completed_offset": completed_offset,
+        }
+        if provisional:
+            turn["provisional"] = True
+        return turn
 
     with open(path, "r", encoding="utf-8") as f:
         if offset > 0:
             f.seek(offset)
 
         while True:
+            line_start = f.tell()
             line = f.readline()
             if not line:
                 break
@@ -84,7 +105,6 @@ def parse_jsonl_file(
                 continue
 
             entry_type = entry.get("type", "")
-
             if entry_type == "summary":
                 continue
 
@@ -93,29 +113,32 @@ def parse_jsonl_file(
             timestamp = entry.get("timestamp", "")
 
             if entry_type == "user":
+                if pending_user is not None and asst_parts:
+                    yield _build(line_start)
+                    message_index += 1
                 text, tool_text = extract_content(content)
                 pending_user = {
                     "text": text,
                     "tool_result": tool_text,
                     "timestamp": timestamp,
                 }
+                asst_parts = []
+                asst_tools = []
+                last_ts = ""
+                turn_start = line_start
 
-            elif entry_type == "assistant" and pending_user is not None:
+            elif entry_type == "assistant":
+                if pending_user is None:
+                    continue
                 text, tool_text = extract_content(content)
-                combined_tool = "\n".join(
-                    filter(None, [pending_user["tool_result"], tool_text])
-                )
-                completed_offset = f.tell()
-                yield {
-                    "user_text": pending_user["text"],
-                    "assistant_text": text,
-                    "tool_result_text": combined_tool[:TOOL_RESULT_MAX],
-                    "timestamp": timestamp or pending_user["timestamp"],
-                    "message_index": message_index,
-                    "completed_offset": completed_offset,
-                }
-                message_index += 1
-                pending_user = None
+                if text:
+                    asst_parts.append(text)
+                if tool_text:
+                    asst_tools.append(tool_text)
+                last_ts = timestamp
+
+        if pending_user is not None and asst_parts:
+            yield _build(turn_start, provisional=True)
 
 def get_file_end_offset(path: str) -> int:
     with open(path, "rb") as f:

--- a/src/deja/parsers/claude_code.py
+++ b/src/deja/parsers/claude_code.py
@@ -1,8 +1,27 @@
+import glob
 import json
+import os
 import sys
-from typing import Generator
+from typing import Generator, Iterator
 
+from deja.config import CLAUDE_PROJECTS_DIR
+
+SOURCE = "claude-code"
 TOOL_RESULT_MAX = 2000
+
+
+def discover() -> Iterator[tuple[str, str]]:
+    """Walk ~/.claude/projects/<project>/*.jsonl, yield (path, project_dir)."""
+    if not os.path.isdir(CLAUDE_PROJECTS_DIR):
+        print(f"[deja] {CLAUDE_PROJECTS_DIR} not found", file=sys.stderr)
+        return
+
+    for project_dir in os.listdir(CLAUDE_PROJECTS_DIR):
+        full_project = os.path.join(CLAUDE_PROJECTS_DIR, project_dir)
+        if not os.path.isdir(full_project):
+            continue
+        for jsonl in glob.glob(os.path.join(full_project, "*.jsonl")):
+            yield jsonl, project_dir
 
 def extract_content(content) -> tuple[str, str]:
     if isinstance(content, str):
@@ -102,3 +121,6 @@ def get_file_end_offset(path: str) -> int:
     with open(path, "rb") as f:
         f.seek(0, 2)
         return f.tell()
+
+
+parse = parse_jsonl_file

--- a/src/deja/parsers/claude_code.py
+++ b/src/deja/parsers/claude_code.py
@@ -5,6 +5,7 @@ import sys
 from typing import Generator, Iterator
 
 from deja.config import CLAUDE_PROJECTS_DIR
+from deja.secrets import redact_turn
 
 SOURCE = "claude-code"
 TOOL_RESULT_MAX = 2000
@@ -52,7 +53,7 @@ def extract_content(content) -> tuple[str, str]:
                     b.get("text", "") for b in raw if isinstance(b, dict)
                 )
             if isinstance(raw, str):
-                tool_result_parts.append(raw[:TOOL_RESULT_MAX])
+                tool_result_parts.append(raw)
 
         elif block_type == "thinking":
             continue
@@ -76,13 +77,15 @@ def parse_jsonl_file(
         turn = {
             "user_text": pending_user["text"],
             "assistant_text": "\n\n".join(asst_parts),
-            "tool_result_text": combined_tool[:TOOL_RESULT_MAX],
+            "tool_result_text": combined_tool,
             "timestamp": last_ts or pending_user["timestamp"],
             "message_index": message_index,
             "completed_offset": completed_offset,
         }
         if provisional:
             turn["provisional"] = True
+        turn = redact_turn(turn)
+        turn["tool_result_text"] = turn["tool_result_text"][:TOOL_RESULT_MAX]
         return turn
 
     with open(path, "r", encoding="utf-8") as f:

--- a/src/deja/parsers/codex.py
+++ b/src/deja/parsers/codex.py
@@ -105,7 +105,7 @@ def parse(
     asst_parts: list[str] = []
     tool_parts: list[str] = []
     pending_ts = ""
-    pending_user_line_start = offset
+    turn_start = offset
     message_index = start_message_index
 
     with open(path, "r", encoding="utf-8") as f:
@@ -146,7 +146,7 @@ def parse(
                 asst_parts = []
                 tool_parts = []
                 pending_ts = ts
-                pending_user_line_start = line_start
+                turn_start = line_start
 
             elif ptype == "message" and role == "assistant":
                 if pending_user is None:
@@ -169,7 +169,9 @@ def parse(
             # developer messages, etc.
 
         if pending_user is not None and asst_parts:
-            yield _build_turn(
+            turn = _build_turn(
                 pending_user, asst_parts, tool_parts,
-                pending_ts, message_index, f.tell(),
+                pending_ts, message_index, turn_start,
             )
+            turn["provisional"] = True
+            yield turn

--- a/src/deja/parsers/codex.py
+++ b/src/deja/parsers/codex.py
@@ -4,7 +4,7 @@ import os
 import sys
 from typing import Generator, Iterator
 
-from deja.config import CODEX_SESSIONS_DIR
+from deja import config
 
 SOURCE = "codex"
 TOOL_RESULT_MAX = 2000
@@ -18,10 +18,11 @@ def discover() -> Iterator[tuple[str, str]]:
     filesystem tree directly rather than trusting session_index.jsonl,
     which can drift (per clean-my-agent maintainer's note on #8).
     """
-    if not os.path.isdir(CODEX_SESSIONS_DIR):
+    root = config.CODEX_SESSIONS_DIR
+    if not os.path.isdir(root):
         return
 
-    pattern = os.path.join(CODEX_SESSIONS_DIR, "**", "*.jsonl")
+    pattern = os.path.join(root, "**", "*.jsonl")
     for path in glob.iglob(pattern, recursive=True):
         if os.path.basename(path) == "session_index.jsonl":
             continue

--- a/src/deja/parsers/codex.py
+++ b/src/deja/parsers/codex.py
@@ -5,6 +5,7 @@ import sys
 from typing import Generator, Iterator
 
 from deja import config
+from deja.secrets import redact_turn
 
 SOURCE = "codex"
 TOOL_RESULT_MAX = 2000
@@ -69,7 +70,7 @@ def _format_tool_output(payload: dict) -> str:
         output = output.get("content") or json.dumps(output, ensure_ascii=False)
     elif isinstance(output, list):
         output = json.dumps(output, ensure_ascii=False)
-    return str(output)[:TOOL_RESULT_MAX]
+    return str(output)
 
 
 def _build_turn(
@@ -81,14 +82,17 @@ def _build_turn(
     completed_offset: int,
 ) -> dict:
     combined_tool = "\n".join(p for p in tool_parts if p)
-    return {
+    turn = {
         "user_text": user_text,
         "assistant_text": "\n\n".join(p for p in asst_parts if p),
-        "tool_result_text": combined_tool[:TOOL_RESULT_MAX],
+        "tool_result_text": combined_tool,
         "timestamp": timestamp,
         "message_index": message_index,
         "completed_offset": completed_offset,
     }
+    turn = redact_turn(turn)
+    turn["tool_result_text"] = turn["tool_result_text"][:TOOL_RESULT_MAX]
+    return turn
 
 
 def parse(

--- a/src/deja/parsers/codex.py
+++ b/src/deja/parsers/codex.py
@@ -1,0 +1,174 @@
+import glob
+import json
+import os
+import sys
+from typing import Generator, Iterator
+
+from deja.config import CODEX_SESSIONS_DIR
+
+SOURCE = "codex"
+TOOL_RESULT_MAX = 2000
+TOOL_ARGS_MAX = 200
+
+
+def discover() -> Iterator[tuple[str, str]]:
+    """Walk ~/.codex/sessions/YYYY/MM/DD/*.jsonl, yield (path, cwd).
+
+    cwd is read from each file's first-line session_meta. We walk the
+    filesystem tree directly rather than trusting session_index.jsonl,
+    which can drift (per clean-my-agent maintainer's note on #8).
+    """
+    if not os.path.isdir(CODEX_SESSIONS_DIR):
+        return
+
+    pattern = os.path.join(CODEX_SESSIONS_DIR, "**", "*.jsonl")
+    for path in glob.iglob(pattern, recursive=True):
+        if os.path.basename(path) == "session_index.jsonl":
+            continue
+        cwd = _read_session_cwd(path)
+        yield path, cwd
+
+
+def _read_session_cwd(path: str) -> str:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            first = f.readline().strip()
+        if not first:
+            return "unknown"
+        entry = json.loads(first)
+        if entry.get("type") != "session_meta":
+            return "unknown"
+        return entry.get("payload", {}).get("cwd", "unknown") or "unknown"
+    except (OSError, json.JSONDecodeError):
+        return "unknown"
+
+
+def _extract_message_text(payload: dict) -> str:
+    parts = []
+    for block in payload.get("content", []) or []:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type", "")
+        if btype in ("input_text", "output_text", "text"):
+            parts.append(block.get("text", ""))
+    return "\n".join(p for p in parts if p)
+
+
+def _format_tool_call(payload: dict) -> str:
+    name = payload.get("name", "tool")
+    args = payload.get("arguments", "")
+    if isinstance(args, (dict, list)):
+        args = json.dumps(args, ensure_ascii=False)
+    return f"[Tool: {name}] {str(args)[:TOOL_ARGS_MAX]}"
+
+
+def _format_tool_output(payload: dict) -> str:
+    output = payload.get("output", "")
+    if isinstance(output, dict):
+        output = output.get("content") or json.dumps(output, ensure_ascii=False)
+    elif isinstance(output, list):
+        output = json.dumps(output, ensure_ascii=False)
+    return str(output)[:TOOL_RESULT_MAX]
+
+
+def _build_turn(
+    user_text: str,
+    asst_parts: list[str],
+    tool_parts: list[str],
+    timestamp: str,
+    message_index: int,
+    completed_offset: int,
+) -> dict:
+    combined_tool = "\n".join(p for p in tool_parts if p)
+    return {
+        "user_text": user_text,
+        "assistant_text": "\n\n".join(p for p in asst_parts if p),
+        "tool_result_text": combined_tool[:TOOL_RESULT_MAX],
+        "timestamp": timestamp,
+        "message_index": message_index,
+        "completed_offset": completed_offset,
+    }
+
+
+def parse(
+    path: str, offset: int = 0, start_message_index: int = 0
+) -> Generator[dict, None, None]:
+    """Parse a Codex rollout JSONL into normalized (user, assistant, tools) turns.
+
+    Pairing strategy: one turn = one user message + every assistant message and
+    every function_call / function_call_output up to the next user message.
+    This preserves multi-step tool loops (typical of GPT agents) instead of
+    discarding all but the first assistant reply.
+    """
+    pending_user = None
+    asst_parts: list[str] = []
+    tool_parts: list[str] = []
+    pending_ts = ""
+    pending_user_line_start = offset
+    message_index = start_message_index
+
+    with open(path, "r", encoding="utf-8") as f:
+        if offset > 0:
+            f.seek(offset)
+
+        while True:
+            line_start = f.tell()
+            line = f.readline()
+            if not line:
+                break
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            try:
+                entry = json.loads(stripped)
+            except json.JSONDecodeError:
+                print(f"[deja] skipping malformed line in {path}", file=sys.stderr)
+                continue
+
+            if entry.get("type") != "response_item":
+                continue
+
+            payload = entry.get("payload", {}) or {}
+            ptype = payload.get("type", "")
+            role = payload.get("role", "")
+            ts = entry.get("timestamp", "")
+
+            if ptype == "message" and role == "user":
+                if pending_user is not None and asst_parts:
+                    yield _build_turn(
+                        pending_user, asst_parts, tool_parts,
+                        pending_ts, message_index, line_start,
+                    )
+                    message_index += 1
+                pending_user = _extract_message_text(payload)
+                asst_parts = []
+                tool_parts = []
+                pending_ts = ts
+                pending_user_line_start = line_start
+
+            elif ptype == "message" and role == "assistant":
+                if pending_user is None:
+                    continue
+                text = _extract_message_text(payload)
+                if text:
+                    asst_parts.append(text)
+
+            elif ptype in ("function_call", "custom_tool_call"):
+                if pending_user is None:
+                    continue
+                tool_parts.append(_format_tool_call(payload))
+
+            elif ptype in ("function_call_output", "custom_tool_call_output"):
+                if pending_user is None:
+                    continue
+                tool_parts.append(_format_tool_output(payload))
+
+            # skip everything else: reasoning, web_search_call,
+            # developer messages, etc.
+
+        if pending_user is not None and asst_parts:
+            yield _build_turn(
+                pending_user, asst_parts, tool_parts,
+                pending_ts, message_index, f.tell(),
+            )

--- a/src/deja/parsers/registry.py
+++ b/src/deja/parsers/registry.py
@@ -1,0 +1,17 @@
+from deja.parsers import claude_code
+
+PARSERS = {
+    claude_code.SOURCE: claude_code,
+}
+
+
+def get_parser(source: str):
+    if source not in PARSERS:
+        raise ValueError(
+            f"Unknown source '{source}'. Available: {sorted(PARSERS)}"
+        )
+    return PARSERS[source]
+
+
+def all_sources() -> list[str]:
+    return sorted(PARSERS)

--- a/src/deja/parsers/registry.py
+++ b/src/deja/parsers/registry.py
@@ -1,7 +1,8 @@
-from deja.parsers import claude_code
+from deja.parsers import claude_code, codex
 
 PARSERS = {
     claude_code.SOURCE: claude_code,
+    codex.SOURCE: codex,
 }
 
 

--- a/src/deja/search.py
+++ b/src/deja/search.py
@@ -110,22 +110,39 @@ def _apply_time_decay(results: list[dict], alpha: float = TIME_DECAY_ALPHA) -> l
     return results
 
 
+def _annotate_source(conn, results: list[dict]) -> list[dict]:
+    if not results:
+        return results
+    ids = [r["id"] for r in results]
+    placeholders = ",".join("?" * len(ids))
+    rows = conn.execute(
+        f"SELECT id, source FROM chunks WHERE id IN ({placeholders})", ids
+    ).fetchall()
+    source_by_id = {row[0]: row[1] for row in rows}
+    for r in results:
+        r["source"] = source_by_id.get(r["id"], "claude-code")
+    return results
+
+
 def hybrid_search(
     conn, model, query: str, limit: int = 10,
     project: str = None, date_from: str = None, date_to: str = None,
-    time_decay: bool = False,
+    source: str = None, time_decay: bool = False,
 ) -> list[dict]:
-    has_filters = project or date_from or date_to
+    has_filters = project or date_from or date_to or source
     k = 100 if has_filters else 20
     vec_results = _vector_search(conn, model, query, k=k)
     fts_results = _fts_search(conn, query, k=k)
     merged = _rrf_merge(vec_results, fts_results)
+    merged = _annotate_source(conn, merged)
 
     if time_decay:
         merged = _apply_time_decay(merged)
 
     if project:
         merged = [r for r in merged if r.get("project_path") == project]
+    if source:
+        merged = [r for r in merged if r.get("source") == source]
     if date_from:
         merged = [r for r in merged if r.get("timestamp", "") >= date_from]
     if date_to:

--- a/src/deja/secrets.py
+++ b/src/deja/secrets.py
@@ -41,12 +41,13 @@ PATTERNS = [
     re.compile(r'-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]+'),
     # Bare well-known token formats (appear in env dumps / configs without assignment context)
     re.compile(r'\bsk-(?:ant|proj)-[A-Za-z0-9_\-]{16,}'),
-    re.compile(r'\b(?:dop_v1_|figd_|npm_)[A-Za-z0-9_\-]{15,}'),
-    re.compile(r'\bpypi-AgEIcHlwaS5vcmc[A-Za-z0-9_\-]{15,}'),
+    re.compile(r'\b(?:dop_v1_|doo_v1_|dor_v1_|figd_)[A-Za-z0-9_\-]{15,}'),
+    re.compile(r'\bnpm_[A-Za-z0-9]{36}\b'),
+    re.compile(r'\bpypi-AgEIc[A-Za-z0-9_\-]{20,}'),
     re.compile(r'\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}'),  # JWT
     re.compile(r'\bAIza[0-9A-Za-z_\-]{35}'),
     re.compile(r'\b[rs]k_live_[A-Za-z0-9]{20,}'),  # Stripe
-    re.compile(r'\b\d{8,10}:AA[A-Za-z0-9_\-]{33}'),  # Telegram bot
+    re.compile(r'\b\d{7,}:AA[A-Za-z0-9_\-]{33,}'),  # Telegram bot
 ]
 
 

--- a/src/deja/secrets.py
+++ b/src/deja/secrets.py
@@ -37,6 +37,8 @@ PATTERNS = [
     re.compile(r'://[^:/@\s]+:([^@\s]{6,})@'),
     # login / password pairs (slash separated)
     re.compile(r'(?i)(?:логин|login)\s*/\s*\S+\s*/\s*(\S{6,})'),
+    # Truncation fallback: BEGIN header without END still gets redacted
+    re.compile(r'-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]+'),
 ]
 
 
@@ -46,3 +48,11 @@ def redact(text: str) -> str:
     for pattern in PATTERNS:
         text = pattern.sub(REDACTED, text)
     return text
+
+
+def redact_turn(turn: dict) -> dict:
+    turn["user_text"] = redact(turn["user_text"])
+    turn["assistant_text"] = redact(turn["assistant_text"])
+    if turn.get("tool_result_text"):
+        turn["tool_result_text"] = redact(turn["tool_result_text"])
+    return turn

--- a/src/deja/secrets.py
+++ b/src/deja/secrets.py
@@ -39,6 +39,14 @@ PATTERNS = [
     re.compile(r'(?i)(?:логин|login)\s*/\s*\S+\s*/\s*(\S{6,})'),
     # Truncation fallback: BEGIN header without END still gets redacted
     re.compile(r'-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]+'),
+    # Bare well-known token formats (appear in env dumps / configs without assignment context)
+    re.compile(r'\bsk-(?:ant|proj)-[A-Za-z0-9_\-]{16,}'),
+    re.compile(r'\b(?:dop_v1_|figd_|npm_)[A-Za-z0-9_\-]{15,}'),
+    re.compile(r'\bpypi-AgEIcHlwaS5vcmc[A-Za-z0-9_\-]{15,}'),
+    re.compile(r'\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}'),  # JWT
+    re.compile(r'\bAIza[0-9A-Za-z_\-]{35}'),
+    re.compile(r'\b[rs]k_live_[A-Za-z0-9]{20,}'),  # Stripe
+    re.compile(r'\b\d{8,10}:AA[A-Za-z0-9_\-]{33}'),  # Telegram bot
 ]
 
 

--- a/src/deja/server.py
+++ b/src/deja/server.py
@@ -56,9 +56,10 @@ async def lifespan(server):
 mcp = FastMCP("deja", lifespan=lifespan)
 
 
-def _do_search(conn, model, query, limit=10, project=None, date_from=None, date_to=None):
+def _do_search(conn, model, query, limit=10, project=None, source=None, date_from=None, date_to=None):
     return hybrid_search(conn, model, query, limit=limit,
-                         project=project, date_from=date_from, date_to=date_to)
+                         project=project, source=source,
+                         date_from=date_from, date_to=date_to)
 
 
 def _do_get_session(conn, session_id):
@@ -108,18 +109,22 @@ async def search(
     query: str,
     limit: int = 10,
     project: str = None,
+    source: str = None,
     date_from: str = None,
     date_to: str = None,
     ctx: Context = None,
 ) -> list[dict]:
-    """Search past Claude Code sessions by meaning. Returns relevant conversation chunks with context."""
+    """Search past AI agent sessions by meaning. Returns relevant conversation chunks with context.
+
+    source: optional filter, e.g. 'claude-code' or 'codex'.
+    """
     lc = ctx.lifespan_context
     lazy_model = lc.get("model")
     db = lc.get("db")
     if lazy_model is None or db is None:
         raise ToolError("Index not loaded. Run 'deja index' first.")
     model = await asyncio.to_thread(lazy_model.get)
-    return await asyncio.to_thread(_do_search, db, model, query, limit, project, date_from, date_to)
+    return await asyncio.to_thread(_do_search, db, model, query, limit, project, source, date_from, date_to)
 
 
 @mcp.tool()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,9 @@
 import os
+import sqlite3
 import tempfile
+
+import sqlite_vec
+
 from deja.db import init_db, get_meta, SCHEMA_VERSION
 
 def test_init_db_creates_tables():
@@ -32,4 +36,82 @@ def test_wal_mode_enabled():
         conn = init_db(db_path)
         mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
         assert mode == "wal"
+        conn.close()
+
+def _make_v1_db(db_path):
+    """Build a DB exactly as schema v1 created it: chunks without `source`."""
+    conn = sqlite3.connect(db_path)
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    conn.executescript("""
+        CREATE TABLE chunks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            message_index INTEGER NOT NULL,
+            split_index INTEGER NOT NULL DEFAULT 0,
+            timestamp TEXT,
+            project_path TEXT,
+            chunk_text TEXT NOT NULL,
+            tool_result_text TEXT,
+            UNIQUE(session_id, message_index, split_index)
+        );
+        CREATE TABLE indexed_files (
+            path TEXT PRIMARY KEY,
+            last_offset INTEGER NOT NULL DEFAULT 0,
+            last_mtime REAL NOT NULL,
+            last_size INTEGER NOT NULL
+        );
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE INDEX idx_chunks_session ON chunks(session_id);
+        CREATE INDEX idx_chunks_project_time ON chunks(project_path, timestamp);
+        INSERT INTO meta VALUES ('schema_version', '1');
+        INSERT INTO chunks (session_id, message_index, split_index, chunk_text)
+            VALUES ('old-sess', 0, 0, 'v1 data');
+        INSERT INTO indexed_files VALUES ('/old/path.jsonl', 100, 1.0, 100);
+    """)
+    conn.execute("CREATE VIRTUAL TABLE chunks_vec USING vec0(embedding float[384])")
+    conn.execute("""
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            chunk_text, tool_result_text, tokenize = "unicode61 tokenchars '-._/:'"
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+def test_init_db_migrates_v1_database():
+    """Opening a v1 DB with current code must not crash and must rebuild schema."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        _make_v1_db(db_path)
+
+        conn = init_db(db_path)
+
+        meta = get_meta(conn)
+        assert meta["schema_version"] == str(SCHEMA_VERSION)
+
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(chunks)").fetchall()]
+        assert "source" in cols
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(indexed_files)").fetchall()]
+        assert "source" in cols
+
+        # Old data dropped — stale offsets must not survive into the new schema
+        assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM indexed_files").fetchone()[0] == 0
+        conn.close()
+
+def test_init_db_idempotent_on_current_schema():
+    """Re-opening a current-version DB must not drop data."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        conn = init_db(db_path)
+        conn.execute(
+            "INSERT INTO chunks (session_id, message_index, split_index, chunk_text) "
+            "VALUES ('s1', 0, 0, 'keep me')"
+        )
+        conn.commit()
+        conn.close()
+
+        conn = init_db(db_path)
+        assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 1
         conn.close()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from deja.db import init_db, get_meta
+from deja.db import init_db, get_meta, SCHEMA_VERSION
 
 def test_init_db_creates_tables():
     with tempfile.TemporaryDirectory() as tmp:
@@ -21,7 +21,7 @@ def test_meta_table_has_schema_version():
         db_path = os.path.join(tmp, "test.db")
         conn = init_db(db_path)
         meta = get_meta(conn)
-        assert meta["schema_version"] == "1"
+        assert meta["schema_version"] == str(SCHEMA_VERSION)
         assert meta["embedding_model"] == "intfloat/multilingual-e5-small"
         assert meta["embedding_dim"] == "384"
         conn.close()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -417,3 +417,20 @@ def test_file_meta_uses_preparse_stat():
         row = conn.execute("SELECT last_size FROM indexed_files WHERE path = ?", (path,)).fetchone()
         assert row[0] == stat_before.st_size, "Meta must record pre-parse size so growth triggers reindex"
         conn.close()
+
+
+def test_secret_at_chunk_boundary_not_leaked():
+    secret = "password=SuperBoundarySecret99"
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        conn = init_db(db_path)
+        model = get_embedding_model()
+        long_text = "x" * 1495 + " " + secret + " " + "y" * 1500
+        path = _make_session(tmp, "sess.jsonl", [
+            {"type": "user", "message": {"content": [{"type": "text", "text": "long"}]}, "timestamp": "2026-01-01T00:00:00Z", "uuid": "1"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": long_text}]}, "timestamp": "2026-01-01T00:00:01Z", "uuid": "2"},
+        ])
+        index_file(conn, model, path, "proj")
+        for (text,) in conn.execute("SELECT chunk_text FROM chunks").fetchall():
+            assert "SuperBoundarySecret" not in text
+        conn.close()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -357,6 +357,45 @@ def test_provisional_turn_shrink_clears_stale_splits():
         conn.close()
 
 
+def test_growth_during_parse_detected_next_run(monkeypatch):
+    """File growth DURING parsing must leave meta stale so the next run reindexes (m2)."""
+    from deja.parsers import claude_code
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        conn = init_db(db_path)
+        model = get_embedding_model()
+        path = _make_session(tmp, "sess.jsonl", [
+            {"type": "user", "message": {"content": [{"type": "text", "text": "q1"}]}, "timestamp": "2026-01-01T00:00:00Z", "uuid": "1"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "a1"}]}, "timestamp": "2026-01-01T00:00:01Z", "uuid": "2"},
+        ])
+
+        real_parse = claude_code.parse_jsonl_file
+
+        def growing_parse(p, offset=0, start_message_index=0):
+            yield from real_parse(p, offset=offset, start_message_index=start_message_index)
+            # file grows AFTER the parser finished reading but BEFORE meta is written
+            _append_lines(p, [
+                {"type": "user", "message": {"content": [{"type": "text", "text": "q2 grown"}]}, "timestamp": "2026-01-01T00:01:00Z", "uuid": "3"},
+                {"type": "assistant", "message": {"content": [{"type": "text", "text": "a2 grown"}]}, "timestamp": "2026-01-01T00:01:01Z", "uuid": "4"},
+            ])
+
+        monkeypatch.setattr(claude_code, "parse_jsonl_file", growing_parse)
+        monkeypatch.setattr(claude_code, "parse", growing_parse)
+        index_file(conn, model, path, "proj")
+        monkeypatch.undo()
+
+        # with the pre-parse stat recorded, the next run MUST see the growth
+        from deja.indexer import check_needs_reindex
+        needs = check_needs_reindex(conn, path)
+        assert needs != False, "Growth during parse must trigger reindex on next run"
+
+        index_file(conn, model, path, "proj")
+        texts = [r[0] for r in conn.execute("SELECT chunk_text FROM chunks").fetchall()]
+        assert any("grown" in t for t in texts), "Turn appended during parse must be indexed by next run"
+        conn.close()
+
+
 def test_file_meta_uses_preparse_stat():
     """Growth during indexing must be picked up by the next run (m2)."""
     with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -69,51 +69,49 @@ def test_safe_reindex_on_truncation():
         conn.close()
 
 def test_incremental_append_no_collision():
-    """New turns appended to file get correct message_index, not colliding with old ones."""
+    """New turns appended to file get correct message_index; completed turns keep stable ids.
+
+    Note: the LAST turn of a file is provisional (re-upserted fuller on next run),
+    so only chunks below next_message_index are guaranteed id-stable.
+    """
     with tempfile.TemporaryDirectory() as tmp:
         db_path = os.path.join(tmp, "test.db")
         conn = init_db(db_path)
         model = get_embedding_model()
 
-        # Index first turn
+        # Run 1: turn 0 completes (user2 follows it), turn 1 is the provisional tail
         path = _make_session(tmp, "sess.jsonl", [
             {"type": "user", "message": {"content": [{"type": "text", "text": "first question"}]}, "timestamp": "2026-01-01T00:00:00Z", "uuid": "1"},
             {"type": "assistant", "message": {"content": [{"type": "text", "text": "first answer"}]}, "timestamp": "2026-01-01T00:00:01Z", "uuid": "2"},
-        ])
-        index_file(conn, model, path, "proj")
-        count1 = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
-        assert count1 >= 1
-
-        old_ids = {r[0] for r in conn.execute("SELECT id FROM chunks").fetchall()}
-        old_texts = {r[0] for r in conn.execute("SELECT chunk_text FROM chunks").fetchall()}
-        assert any("first" in t for t in old_texts)
-
-        # Append second turn
-        time.sleep(0.1)  # ensure mtime changes
-        _append_lines(path, [
             {"type": "user", "message": {"content": [{"type": "text", "text": "second question"}]}, "timestamp": "2026-01-01T00:01:00Z", "uuid": "3"},
             {"type": "assistant", "message": {"content": [{"type": "text", "text": "second answer"}]}, "timestamp": "2026-01-01T00:01:01Z", "uuid": "4"},
         ])
-
         index_file(conn, model, path, "proj")
-        count2 = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
-        assert count2 >= 2, f"Expected at least 2 chunks, got {count2}"
+        turn0_ids = {r[0] for r in conn.execute(
+            "SELECT id FROM chunks WHERE message_index = 0").fetchall()}
+        assert turn0_ids, "turn 0 must be indexed"
 
-        # Old chunks must still exist with same IDs
-        new_ids = {r[0] for r in conn.execute("SELECT id FROM chunks").fetchall()}
-        assert old_ids.issubset(new_ids), "Old chunk IDs should be preserved"
+        # Run 2: append turn 2; turn 1 (was provisional) is re-upserted, turn 0 untouched
+        time.sleep(0.1)
+        _append_lines(path, [
+            {"type": "user", "message": {"content": [{"type": "text", "text": "third question"}]}, "timestamp": "2026-01-01T00:02:00Z", "uuid": "5"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "third answer"}]}, "timestamp": "2026-01-01T00:02:01Z", "uuid": "6"},
+        ])
+        index_file(conn, model, path, "proj")
 
-        # Both turns must be present
-        all_texts = [r[0] for r in conn.execute("SELECT chunk_text FROM chunks ORDER BY message_index").fetchall()]
-        assert any("first" in t for t in all_texts), "First turn should still exist"
-        assert any("second" in t for t in all_texts), "Second turn should be added"
+        turn0_ids_after = {r[0] for r in conn.execute(
+            "SELECT id FROM chunks WHERE message_index = 0").fetchall()}
+        assert turn0_ids_after == turn0_ids, "Completed turns below next_message_index must keep stable ids"
 
-        # message_index should be distinct
+        all_texts = [r[0] for r in conn.execute(
+            "SELECT chunk_text FROM chunks ORDER BY message_index").fetchall()]
+        assert any("first" in t for t in all_texts)
+        assert any("second" in t for t in all_texts)
+        assert any("third" in t for t in all_texts)
+
         indices = [r[0] for r in conn.execute(
-            "SELECT DISTINCT message_index FROM chunks ORDER BY message_index"
-        ).fetchall()]
-        assert len(indices) >= 2, f"Expected distinct message indices, got {indices}"
-        assert indices[0] != indices[1], "Message indices must not collide"
+            "SELECT DISTINCT message_index FROM chunks ORDER BY message_index").fetchall()]
+        assert indices == [0, 1, 2], f"Expected message indices [0, 1, 2], got {indices}"
 
         conn.close()
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -3,7 +3,7 @@ import os
 import time
 import tempfile
 from deja.db import init_db
-from deja.indexer import index_file, get_embedding_model, check_needs_reindex
+from deja.indexer import index_file, get_embedding_model, check_needs_reindex, gc_orphans
 
 def _make_session(tmp, filename, lines):
     path = os.path.join(tmp, filename)
@@ -183,4 +183,46 @@ def test_row_consistency_chunks_vec_fts():
         ).fetchone()[0]
         assert orphan_vec == 0, f"Found {orphan_vec} orphan vec rows"
 
+        conn.close()
+
+def test_gc_orphans_scoped_to_sources():
+    """Partial run (--source codex) must not treat other sources' files as orphans."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        conn = init_db(db_path)
+        model = get_embedding_model()
+        path = _make_session(tmp, "cc-sess.jsonl", [
+            {"type": "user", "message": {"content": [{"type": "text", "text": "hello"}]}, "timestamp": "2026-01-01T00:00:00Z", "uuid": "1"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "world"}]}, "timestamp": "2026-01-01T00:00:01Z", "uuid": "2"},
+        ])
+        index_file(conn, model, path, "proj", source="claude-code")
+        assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] >= 1
+
+        # gc scoped to codex: claude-code file is NOT in known_paths but must survive
+        gc_orphans(conn, set(), sources=["codex"])
+        assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] >= 1
+        assert conn.execute("SELECT COUNT(*) FROM indexed_files").fetchone()[0] == 1
+
+        # gc scoped to claude-code: now it is a real orphan and gets removed
+        gc_orphans(conn, set(), sources=["claude-code"])
+        assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM indexed_files").fetchone()[0] == 0
+
+        conn.close()
+
+def test_gc_orphans_unscoped_removes_all():
+    """sources=None keeps the old global behaviour (full `deja index` run)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        conn = init_db(db_path)
+        model = get_embedding_model()
+        path = _make_session(tmp, "cc-sess.jsonl", [
+            {"type": "user", "message": {"content": [{"type": "text", "text": "hello"}]}, "timestamp": "2026-01-01T00:00:00Z", "uuid": "1"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "world"}]}, "timestamp": "2026-01-01T00:00:01Z", "uuid": "2"},
+        ])
+        index_file(conn, model, path, "proj", source="claude-code")
+
+        gc_orphans(conn, set())
+        assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM indexed_files").fetchone()[0] == 0
         conn.close()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -355,3 +355,26 @@ def test_provisional_turn_shrink_clears_stale_splits():
             "SELECT COUNT(*) FROM chunks_vec WHERE rowid NOT IN (SELECT id FROM chunks)").fetchone()[0]
         assert orphan_vec == 0, f"{orphan_vec} orphan vector rows after provisional re-upsert"
         conn.close()
+
+
+def test_file_meta_uses_preparse_stat():
+    """Growth during indexing must be picked up by the next run (m2)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        conn = init_db(db_path)
+        path = _make_session(tmp, "sess.jsonl", [
+            {"type": "user", "message": {"content": [{"type": "text", "text": "q1"}]}, "timestamp": "2026-01-01T00:00:00Z", "uuid": "1"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "a1"}]}, "timestamp": "2026-01-01T00:00:01Z", "uuid": "2"},
+        ])
+        stat_before = os.stat(path)
+        from deja.indexer import _update_file_meta
+        time.sleep(0.05)
+        _append_lines(path, [
+            {"type": "user", "message": {"content": [{"type": "text", "text": "q2"}]}, "timestamp": "2026-01-01T00:01:00Z", "uuid": "3"},
+        ])
+        _update_file_meta(conn, path, 10, source="claude-code",
+                          next_message_index=1, stat_result=stat_before)
+        conn.commit()
+        row = conn.execute("SELECT last_size FROM indexed_files WHERE path = ?", (path,)).fetchone()
+        assert row[0] == stat_before.st_size, "Meta must record pre-parse size so growth triggers reindex"
+        conn.close()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -226,3 +226,26 @@ def test_gc_orphans_unscoped_removes_all():
         assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 0
         assert conn.execute("SELECT COUNT(*) FROM indexed_files").fetchone()[0] == 0
         conn.close()
+
+def test_file_with_only_dangling_user_indexed_later():
+    """File containing only a user message must not be marked fully indexed (C1)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        conn = init_db(db_path)
+        model = get_embedding_model()
+        path = _make_session(tmp, "sess.jsonl", [
+            {"type": "user", "message": {"content": [{"type": "text", "text": "lonely question"}]}, "timestamp": "2026-01-01T00:00:00Z", "uuid": "1"},
+        ])
+        index_file(conn, model, path, "proj")
+        # offset must be 0, not file size
+        row = conn.execute("SELECT last_offset FROM indexed_files WHERE path = ?", (path,)).fetchone()
+        assert row[0] == 0, f"Expected offset 0 for unindexed dangling user, got {row[0]}"
+
+        time.sleep(0.1)
+        _append_lines(path, [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "late answer"}]}, "timestamp": "2026-01-01T00:00:05Z", "uuid": "2"},
+        ])
+        index_file(conn, model, path, "proj")
+        texts = [r[0] for r in conn.execute("SELECT chunk_text FROM chunks").fetchall()]
+        assert any("lonely" in t for t in texts), "Dangling-only turn must be indexed after assistant arrives"
+        conn.close()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -2,7 +2,7 @@ import json
 import os
 import time
 import tempfile
-from deja.db import init_db
+from deja.db import init_db, serialize_f32
 from deja.indexer import index_file, get_embedding_model, check_needs_reindex, gc_orphans
 
 def _make_session(tmp, filename, lines):
@@ -290,6 +290,70 @@ def test_codex_live_session_tail_grows_without_duplicates():
         turn0 = " ".join(t for i, t in rows if i == 0)
         assert "part one" in turn0 and "part two" in turn0, "Tail of live turn must be re-indexed"
         assert any("answer two" in t for _, t in rows), "Next turn must be indexed"
-        indices = sorted({i for i, _ in rows})
-        assert indices == [0, 1], f"No duplicate/skipped message_index, got {indices}"
+        pairs = [r for r in conn.execute(
+            "SELECT message_index, split_index FROM chunks ORDER BY message_index, split_index"
+        ).fetchall()]
+        assert pairs == sorted(set(pairs)), f"Duplicate (message_index, split_index) rows: {pairs}"
+        assert {p[0] for p in pairs} == {0, 1}, f"Expected exactly turns 0 and 1, got {pairs}"
+        vec_count = conn.execute("SELECT COUNT(*) FROM chunks_vec").fetchone()[0]
+        fts_count = conn.execute("SELECT COUNT(*) FROM chunks_fts").fetchone()[0]
+        chunks_count = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        assert chunks_count == vec_count == fts_count, \
+            f"Row drift: chunks={chunks_count} vec={vec_count} fts={fts_count}"
+        conn.close()
+
+
+def test_provisional_turn_shrink_clears_stale_splits():
+    """_delete_chunks_from must remove stale split rows that re-index will not overwrite."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        conn = init_db(db_path)
+        model = get_embedding_model()
+        # long answer -> multiple split chunks for message_index 0
+        path = _make_session(tmp, "rollout-y.jsonl", [
+            {"type": "session_meta", "payload": {"cwd": "/proj"}},
+            _codex_user("long question"),
+            _codex_asst("A" * 4000),
+        ])
+        index_file(conn, model, path, "/proj", source="codex")
+        splits_before = conn.execute(
+            "SELECT COUNT(*) FROM chunks WHERE message_index = 0").fetchone()[0]
+        assert splits_before > 1, "fixture must produce multiple splits"
+
+        # Inject a stale split row at split_index=splits_before (beyond what re-index produces).
+        # Without _delete_chunks_from this row survives the re-upsert because _upsert_chunk
+        # only touches rows it actually produces — it never deletes extras.
+        session_id = os.path.splitext(os.path.basename(path))[0]
+        cur = conn.execute(
+            "INSERT INTO chunks (session_id, message_index, split_index, timestamp,"
+            " project_path, chunk_text, tool_result_text, source)"
+            " VALUES (?,?,?,?,?,?,?,?)",
+            (session_id, 0, splits_before, "2026-06-01T10:00:05Z", "/proj", "STALE", "", "codex"),
+        )
+        cid = cur.lastrowid
+        conn.execute("INSERT INTO chunks_vec (rowid, embedding) VALUES (?,?)",
+                     (cid, serialize_f32([0.0] * 384)))
+        conn.execute("INSERT INTO chunks_fts (rowid, chunk_text, tool_result_text) VALUES (?,?,?)",
+                     (cid, "STALE", ""))
+        conn.commit()
+
+        # grow the file with a new turn so the incremental path fires and turn 0 is re-upserted
+        time.sleep(0.1)
+        _append_lines(path, [
+            _codex_user("next q", ts="2026-06-01T11:00:00Z"),
+            _codex_asst("short", ts="2026-06-01T11:00:05Z"),
+        ])
+        index_file(conn, model, path, "/proj", source="codex")
+
+        stale = conn.execute(
+            "SELECT COUNT(*) FROM chunks WHERE message_index = 0 AND split_index = ?",
+            (splits_before,),
+        ).fetchone()[0]
+        assert stale == 0, "stale split row must be cleared by _delete_chunks_from"
+        splits_after = conn.execute(
+            "SELECT COUNT(*) FROM chunks WHERE message_index = 0").fetchone()[0]
+        assert splits_after == splits_before, "turn 0 splits must be exactly re-created, no stale extras"
+        orphan_vec = conn.execute(
+            "SELECT COUNT(*) FROM chunks_vec WHERE rowid NOT IN (SELECT id FROM chunks)").fetchone()[0]
+        assert orphan_vec == 0, f"{orphan_vec} orphan vector rows after provisional re-upsert"
         conn.close()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -249,3 +249,47 @@ def test_file_with_only_dangling_user_indexed_later():
         texts = [r[0] for r in conn.execute("SELECT chunk_text FROM chunks").fetchall()]
         assert any("lonely" in t for t in texts), "Dangling-only turn must be indexed after assistant arrives"
         conn.close()
+
+
+def _codex_user(text, ts="2026-06-01T10:00:00Z"):
+    return {"type": "response_item", "timestamp": ts,
+            "payload": {"type": "message", "role": "user",
+                        "content": [{"type": "input_text", "text": text}]}}
+
+def _codex_asst(text, ts="2026-06-01T10:00:05Z"):
+    return {"type": "response_item", "timestamp": ts,
+            "payload": {"type": "message", "role": "assistant",
+                        "content": [{"type": "output_text", "text": text}]}}
+
+def test_codex_live_session_tail_grows_without_duplicates():
+    """Provisional last turn is re-upserted fuller on next run (B3)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        conn = init_db(db_path)
+        model = get_embedding_model()
+        path = _make_session(tmp, "rollout-x.jsonl", [
+            {"type": "session_meta", "payload": {"cwd": "/proj"}},
+            _codex_user("question one"),
+            _codex_asst("answer part one"),
+        ])
+        index_file(conn, model, path, "/proj", source="codex")
+        texts = [r[0] for r in conn.execute("SELECT chunk_text FROM chunks ORDER BY message_index").fetchall()]
+        assert any("part one" in t for t in texts)
+
+        time.sleep(0.1)
+        _append_lines(path, [
+            _codex_asst("answer part two"),
+            _codex_user("question two", ts="2026-06-01T11:00:00Z"),
+            _codex_asst("answer two", ts="2026-06-01T11:00:05Z"),
+        ])
+        index_file(conn, model, path, "/proj", source="codex")
+
+        rows = conn.execute(
+            "SELECT message_index, chunk_text FROM chunks ORDER BY message_index, split_index"
+        ).fetchall()
+        turn0 = " ".join(t for i, t in rows if i == 0)
+        assert "part one" in turn0 and "part two" in turn0, "Tail of live turn must be re-indexed"
+        assert any("answer two" in t for _, t in rows), "Next turn must be indexed"
+        indices = sorted({i for i, _ in rows})
+        assert indices == [0, 1], f"No duplicate/skipped message_index, got {indices}"
+        conn.close()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -434,3 +434,21 @@ def test_secret_at_chunk_boundary_not_leaked():
         for (text,) in conn.execute("SELECT chunk_text FROM chunks").fetchall():
             assert "SuperBoundarySecret" not in text
         conn.close()
+
+
+def test_long_private_key_split_across_chunks_not_leaked():
+    """Key body >> OVERLAP: only chunk 0 carries the BEGIN anchor; per-chunk
+    redaction would leak the body in later chunks. Guards redact-before-split."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        conn = init_db(db_path)
+        model = get_embedding_model()
+        long_text = "-----BEGIN OPENSSH PRIVATE KEY-----\n" + "M" * 2000
+        path = _make_session(tmp, "sess.jsonl", [
+            {"type": "user", "message": {"content": [{"type": "text", "text": "show key"}]}, "timestamp": "2026-01-01T00:00:00Z", "uuid": "1"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": long_text}]}, "timestamp": "2026-01-01T00:00:01Z", "uuid": "2"},
+        ])
+        index_file(conn, model, path, "proj")
+        for (text,) in conn.execute("SELECT chunk_text FROM chunks").fetchall():
+            assert "MMMM" not in text, "Key body must not survive in any chunk"
+        conn.close()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -96,9 +96,26 @@ def test_parse_jsonl_with_offset():
 
 def test_tool_result_truncated_to_2000():
     long_result = "x" * 5000
-    content = [{"type": "tool_result", "content": long_result}]
-    text, tool_text = extract_content(content)
-    assert len(tool_text) <= 2000
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "session.jsonl")
+        _write_jsonl(path, [
+            {"type": "user", "message": {"content": [{"type": "tool_result", "content": long_result}]}, "timestamp": "2026-01-01T00:00:00Z", "uuid": "1"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}, "timestamp": "2026-01-01T00:00:01Z", "uuid": "2"},
+        ])
+        turns = list(parse_jsonl_file(path))
+        assert len(turns[0]["tool_result_text"]) <= 2000
+
+def test_secret_redacted_before_tool_result_truncation():
+    key = "-----BEGIN RSA PRIVATE KEY-----\n" + "B" * 2400 + "\n-----END RSA PRIVATE KEY-----"
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "session.jsonl")
+        _write_jsonl(path, [
+            {"type": "user", "message": {"content": [{"type": "tool_result", "content": key}]}, "timestamp": "2026-01-01T00:00:00Z", "uuid": "1"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "done"}]}, "timestamp": "2026-01-01T00:00:01Z", "uuid": "2"},
+        ])
+        turns = list(parse_jsonl_file(path))
+        assert "BBBB" not in turns[0]["tool_result_text"], "Key must be redacted before truncation"
+
 
 def test_consecutive_assistant_entries_accumulated():
     with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -99,3 +99,19 @@ def test_tool_result_truncated_to_2000():
     content = [{"type": "tool_result", "content": long_result}]
     text, tool_text = extract_content(content)
     assert len(tool_text) <= 2000
+
+def test_consecutive_assistant_entries_accumulated():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "session.jsonl")
+        _write_jsonl(path, [
+            {"type": "user", "message": {"content": [{"type": "text", "text": "do two things"}]}, "timestamp": "2026-01-01T00:00:00Z", "uuid": "1"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "first part"}]}, "timestamp": "2026-01-01T00:00:01Z", "uuid": "2"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "second part"}]}, "timestamp": "2026-01-01T00:00:02Z", "uuid": "3"},
+            {"type": "user", "message": {"content": [{"type": "text", "text": "next"}]}, "timestamp": "2026-01-01T00:01:00Z", "uuid": "4"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "next answer"}]}, "timestamp": "2026-01-01T00:01:01Z", "uuid": "5"},
+        ])
+        turns = list(parse_jsonl_file(path))
+        assert len(turns) == 2
+        assert "first part" in turns[0]["assistant_text"]
+        assert "second part" in turns[0]["assistant_text"], "Second assistant entry must not be dropped"
+        assert turns[1].get("provisional") is True

--- a/tests/test_parser_codex.py
+++ b/tests/test_parser_codex.py
@@ -1,0 +1,238 @@
+import json
+import os
+import tempfile
+
+from deja.parsers import codex
+
+
+def _write_jsonl(path, lines):
+    with open(path, "w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(json.dumps(line, ensure_ascii=False) + "\n")
+
+
+def _session_meta(cwd="C:\\proj"):
+    return {
+        "timestamp": "2026-03-28T00:00:00.000Z",
+        "type": "session_meta",
+        "payload": {
+            "id": "01-test",
+            "cwd": cwd,
+            "originator": "codex_cli_rs",
+            "cli_version": "0.116.0",
+        },
+    }
+
+
+def _msg(role, text, ts="2026-03-28T00:00:01.000Z"):
+    return {
+        "timestamp": ts,
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": role,
+            "content": [{"type": "input_text" if role == "user" else "output_text", "text": text}],
+        },
+    }
+
+
+def _function_call(name, args, ts="2026-03-28T00:00:02.000Z"):
+    return {
+        "timestamp": ts,
+        "type": "response_item",
+        "payload": {"type": "function_call", "name": name, "arguments": args},
+    }
+
+
+def _function_output(output, ts="2026-03-28T00:00:03.000Z"):
+    return {
+        "timestamp": ts,
+        "type": "response_item",
+        "payload": {"type": "function_call_output", "output": output},
+    }
+
+
+def _event(payload_type="task_started"):
+    return {
+        "timestamp": "2026-03-28T00:00:00.500Z",
+        "type": "event_msg",
+        "payload": {"type": payload_type},
+    }
+
+
+def test_basic_user_assistant_pair():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.jsonl")
+        _write_jsonl(path, [
+            _session_meta(),
+            _event(),
+            _msg("user", "fix nginx"),
+            _msg("assistant", "check the config"),
+        ])
+        turns = list(codex.parse(path))
+        assert len(turns) == 1
+        assert "fix nginx" in turns[0]["user_text"]
+        assert "check the config" in turns[0]["assistant_text"]
+        assert turns[0]["message_index"] == 0
+
+
+def test_multi_assistant_between_users_kept():
+    """Tool loop: user -> asst1 (tool plan) -> tool -> asst2 (answer) -> user2"""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.jsonl")
+        _write_jsonl(path, [
+            _session_meta(),
+            _msg("user", "list files"),
+            _msg("assistant", "I'll run ls"),
+            _function_call("shell", '{"cmd":"ls"}'),
+            _function_output("file1\nfile2"),
+            _msg("assistant", "found 2 files"),
+            _msg("user", "next"),
+            _msg("assistant", "done"),
+        ])
+        turns = list(codex.parse(path))
+        assert len(turns) == 2
+        first = turns[0]
+        assert "I'll run ls" in first["assistant_text"]
+        assert "found 2 files" in first["assistant_text"]
+        assert "[Tool: shell]" in first["tool_result_text"]
+        assert "file1" in first["tool_result_text"]
+
+
+def test_developer_and_reasoning_skipped():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.jsonl")
+        _write_jsonl(path, [
+            _session_meta(),
+            {"timestamp": "x", "type": "response_item",
+             "payload": {"type": "message", "role": "developer",
+                         "content": [{"type": "input_text", "text": "system prompt"}]}},
+            {"timestamp": "x", "type": "response_item",
+             "payload": {"type": "reasoning", "summary": "thinking..."}},
+            _msg("user", "hello"),
+            _msg("assistant", "hi"),
+        ])
+        turns = list(codex.parse(path))
+        assert len(turns) == 1
+        assert "system prompt" not in turns[0]["user_text"]
+        assert "thinking" not in turns[0]["assistant_text"]
+
+
+def test_assistant_before_user_is_dropped():
+    """Codex sometimes emits a leading assistant. With no pending user, skip it."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.jsonl")
+        _write_jsonl(path, [
+            _session_meta(),
+            _msg("assistant", "stray"),
+            _msg("user", "real question"),
+            _msg("assistant", "real answer"),
+        ])
+        turns = list(codex.parse(path))
+        assert len(turns) == 1
+        assert "stray" not in turns[0]["assistant_text"]
+
+
+def test_user_without_assistant_not_yielded():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.jsonl")
+        _write_jsonl(path, [
+            _session_meta(),
+            _msg("user", "abandoned"),
+        ])
+        turns = list(codex.parse(path))
+        assert turns == []
+
+
+def test_resume_from_offset_is_idempotent():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.jsonl")
+        _write_jsonl(path, [
+            _session_meta(),
+            _msg("user", "u1"), _msg("assistant", "a1"),
+            _msg("user", "u2"), _msg("assistant", "a2"),
+            _msg("user", "u3"), _msg("assistant", "a3"),
+        ])
+        full = list(codex.parse(path))
+        assert len(full) == 3
+
+        first_two = []
+        gen = codex.parse(path)
+        try:
+            for i, t in enumerate(gen):
+                first_two.append(t)
+                if i == 1:
+                    break
+        finally:
+            gen.close()
+
+        resume_offset = first_two[-1]["completed_offset"]
+        resume_idx = first_two[-1]["message_index"] + 1
+        rest = list(codex.parse(path, offset=resume_offset, start_message_index=resume_idx))
+
+        combined = first_two + rest
+        assert [t["message_index"] for t in combined] == [0, 1, 2]
+        assert [t["user_text"] for t in combined] == [t["user_text"] for t in full]
+
+
+def test_tool_output_truncated():
+    huge = "x" * 5000
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.jsonl")
+        _write_jsonl(path, [
+            _session_meta(),
+            _msg("user", "go"),
+            _function_call("shell", "{}"),
+            _function_output(huge),
+            _msg("assistant", "done"),
+        ])
+        turns = list(codex.parse(path))
+        assert len(turns) == 1
+        assert len(turns[0]["tool_result_text"]) <= 2000
+
+
+def test_discover_walks_date_tree_and_reads_cwd():
+    with tempfile.TemporaryDirectory() as tmp:
+        sessions_root = os.path.join(tmp, "2026", "03", "28")
+        os.makedirs(sessions_root)
+        good = os.path.join(sessions_root, "rollout-a.jsonl")
+        _write_jsonl(good, [_session_meta(cwd="C:\\my\\project"), _msg("user", "x"), _msg("assistant", "y")])
+        idx = os.path.join(tmp, "session_index.jsonl")
+        _write_jsonl(idx, [{"some": "stale"}])
+
+        from deja import config
+        original = config.CODEX_SESSIONS_DIR
+        config.CODEX_SESSIONS_DIR = tmp
+        try:
+            discovered = list(codex.discover())
+        finally:
+            config.CODEX_SESSIONS_DIR = original
+
+        paths = [os.path.basename(p) for p, _ in discovered]
+        cwds = [c for _, c in discovered]
+        assert "rollout-a.jsonl" in paths
+        assert "session_index.jsonl" not in paths
+        assert "C:\\my\\project" in cwds
+
+
+def test_discover_handles_missing_dir():
+    from deja import config
+    original = config.CODEX_SESSIONS_DIR
+    config.CODEX_SESSIONS_DIR = "/path/that/does/not/exist/anywhere"
+    try:
+        assert list(codex.discover()) == []
+    finally:
+        config.CODEX_SESSIONS_DIR = original
+
+
+def test_malformed_line_skipped():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.jsonl")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(json.dumps(_session_meta()) + "\n")
+            f.write(json.dumps(_msg("user", "hi")) + "\n")
+            f.write("NOT JSON\n")
+            f.write(json.dumps(_msg("assistant", "ok")) + "\n")
+        turns = list(codex.parse(path))
+        assert len(turns) == 1
+        assert "hi" in turns[0]["user_text"]

--- a/tests/test_parser_codex.py
+++ b/tests/test_parser_codex.py
@@ -236,3 +236,28 @@ def test_malformed_line_skipped():
         turns = list(codex.parse(path))
         assert len(turns) == 1
         assert "hi" in turns[0]["user_text"]
+
+
+def test_eof_turn_is_provisional_with_turn_start_offset():
+    lines = [
+        {"type": "session_meta", "payload": {"cwd": "/proj"}},
+        {"type": "response_item", "timestamp": "2026-06-01T10:00:00Z",
+         "payload": {"type": "message", "role": "user",
+                     "content": [{"type": "input_text", "text": "first q"}]}},
+        {"type": "response_item", "timestamp": "2026-06-01T10:00:05Z",
+         "payload": {"type": "message", "role": "assistant",
+                     "content": [{"type": "output_text", "text": "partial answer"}]}},
+    ]
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "rollout.jsonl")
+        with open(path, "w", encoding="utf-8") as f:
+            for line in lines:
+                f.write(json.dumps(line) + "\n")
+
+        turns = list(codex.parse(path))
+        assert len(turns) == 1
+        assert turns[0].get("provisional") is True
+        again = list(codex.parse(path, offset=turns[0]["completed_offset"],
+                                 start_message_index=turns[0]["message_index"]))
+        assert len(again) == 1
+        assert again[0]["user_text"] == "first q"

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -47,3 +47,10 @@ def test_redact_private_key():
     text = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----"
     result = redact(text)
     assert "MIIEpAIBAAKCAQEA" not in result
+
+
+def test_truncated_private_key_redacted():
+    text = "-----BEGIN OPENSSH PRIVATE KEY-----\n" + "A" * 3000  # END cut off
+    result = redact(text)
+    assert "AAAA" not in result
+    assert REDACTED in result

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,3 +1,5 @@
+import pytest
+
 from deja.secrets import redact, REDACTED
 
 
@@ -54,3 +56,25 @@ def test_truncated_private_key_redacted():
     result = redact(text)
     assert "AAAA" not in result
     assert REDACTED in result
+
+
+@pytest.mark.parametrize("token", [
+    "sk-ant-api03-AbCdEf123456789012345678901234",
+    "sk-proj-AbCdEf12345678901234567890",
+    "dop_v1_151a47ab23c4def567890abcdef1234567890abcd",
+    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.SflKxwRJSMeKKF2QT4fwpM",
+    "AIzaSyA-1234567890abcdefghijklmnopqrstuv",
+    "sk_live_4eC39HqLyjWDarjtT1zdp7dc12345",
+    "1234567890:AAEhBOweik6ad9r_QXMENQjcrGbqCr4K-pc",
+    "npm_AbCd1234567890efGhIjKlMnOpQrStUvWx",
+])
+def test_redact_bare_tokens(token):
+    text = f"env output:\n{token}\nnext line"
+    result = redact(text)
+    assert token not in result, f"Bare token leaked: {token[:12]}..."
+    assert REDACTED in result
+
+
+def test_redact_still_preserves_normal_text():
+    text = "Fix the skirt-and-blouse layout for nginx proxy in project alpha"
+    assert redact(text) == text

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -66,7 +66,7 @@ def test_truncated_private_key_redacted():
     "AIzaSyA-1234567890abcdefghijklmnopqrstuv",
     "sk_live_4eC39HqLyjWDarjtT1zdp7dc12345",
     "1234567890:AAEhBOweik6ad9r_QXMENQjcrGbqCr4K-pc",
-    "npm_AbCd1234567890efGhIjKlMnOpQrStUvWx",
+    "npm_AbCd1234567890efGhIjKlMnOpQrStUvWxYz",
 ])
 def test_redact_bare_tokens(token):
     text = f"env output:\n{token}\nnext line"
@@ -77,4 +77,23 @@ def test_redact_bare_tokens(token):
 
 def test_redact_still_preserves_normal_text():
     text = "Fix the skirt-and-blouse layout for nginx proxy in project alpha"
+    assert redact(text) == text
+
+
+@pytest.mark.parametrize("token", [
+    "12345678901:AAEhBOweik6ad9r_QXMENQjcrGbqCr4K-pc",  # 11-digit Telegram ID
+    "1234567:AAEhBOweik6ad9r_QXMENQjcrGbqCr4K-pc",      # 7-digit legacy Telegram ID
+    "pypi-AgEIcHRlc3QucHlwaS5vcmc" + "x" * 30,           # TestPyPI
+    "doo_v1_" + "a1b2c3d4e5" * 4,                        # DO OAuth
+    "dor_v1_" + "a1b2c3d4e5" * 4,                        # DO refresh
+    "npm_" + "Ab12Cd34Ef56Gh78Ij90Kl12Mn34Op56Qr78",     # real npm token shape (36 base62)
+])
+def test_redact_bare_tokens_variants(token):
+    result = redact(f"output:\n{token}\nend")
+    assert token not in result
+    assert REDACTED in result
+
+
+def test_npm_env_vars_not_redacted():
+    text = "npm_package_version=1.2.3 npm_config_registry=https://r.npmjs.org npm_lifecycle_event=postinstall"
     assert redact(text) == text


### PR DESCRIPTION
First phase of #8 — multi-source session support. Adds Codex CLI as a second indexable source alongside Claude Code.

## What's in this PR

**Architecture**
- `parsers/` package with a `Parser` Protocol (`SOURCE`, `discover`, `parse`)
- `parsers/registry.py` dispatches by source name; adding the next source (Cursor / Gemini / OpenCode) won't touch the indexer or CLI
- `parser.py` becomes a backwards-compat shim re-exporting from `parsers/claude_code.py`

**Codex support**
- `parsers/codex.py` walks `~/.codex/sessions/YYYY/MM/DD/*.jsonl` directly (ignores `session_index.jsonl`, which drifts — per [@blain3white's note](https://github.com/CynepMyx/deja/issues/8#issuecomment-4660983828))
- One turn = user message + every assistant + every function_call/output up to the next user. Multi-step tool loops (~3 assistant msgs per user in GPT-5 sessions) are preserved; a first-assistant-only pairing would have discarded ~67% of content.
- Project path = `session_meta.payload.cwd`

**DB schema v1 -> v2**
- New `chunks.source` column (`NOT NULL DEFAULT 'claude-code'`)
- New `idx_chunks_source` index
- `cli.py` already auto-reindexes on schema mismatch; users see a clear log message rather than silent breakage

**CLI / MCP**
- `deja index --source {all,claude-code,codex}` (default: all)
- `deja search --source claude-code|codex` filter
- MCP `search` tool gains an optional `source` parameter
- Results now include a `source` field

## Why source filter is needed

In a mixed index (88 Claude Code files vs 4 Codex files in my own test), Codex contributes ~0.22% of chunks. Without a source filter, even queries that match Codex content better never bring Codex hits to the top — they're statistically buried. `--source codex` makes the smaller source usable in isolation.

## End-to-end verification

Indexed both sources into a throwaway DB (`DEJA_INDEX_PATH=...`):
- 92 files (88 claude-code + 4 codex) -> 26,032 chunks (25,974 + 58)
- 78 sessions, schema v2, ` ` Health: OK` from `deja stats`
- `deja search 'freelance-radar безопасность' --source codex` -> 3 hits from the right Codex audit session, all with reasonable scores
- FTS direct probe (`MATCH '\"html.escape\"'`): top Codex chunk ranks ahead of top Claude Code chunk

## Tests

- 10 new tests in `tests/test_parser_codex.py` cover basic pairing, multi-assistant tool loops, skipped roles (developer / reasoning / web_search_call), assistant-before-user dropped, user-without-assistant dropped, resume-from-offset idempotency, tool-output truncation, discover walks the date tree, discover skips `session_index.jsonl`, discover handles missing root, malformed lines skipped
- All 51 tests pass (was 41)

## Commits

1. `refactor: extract claude-code parser into parsers/`
2. `feat: parser registry + Parser protocol`
3. `feat(parsers): Codex JSONL parser`
4. `feat(db): add source column, bump SCHEMA_VERSION 1->2`
5. `feat: --source CLI flag, indexer wired to registry`
6. `test: Codex parser fixtures and discover`
7. `feat(search): --source filter for CLI, MCP tool, and library API`
8. `docs: README — multi-source support, --source flags`

## Out of scope (for follow-up)

- Phase 2: Cursor SQLite parser (#8)
- Pre-filter `source` in vec/fts queries instead of post-merge filter — current implementation matches `project` filter semantics; same fix can apply to both
- CHANGELOG / version bump to v0.4.0 — separate step before release